### PR TITLE
OBlElement>>styles removed

### DIFF
--- a/src/OnBloc/OBlElement.class.st
+++ b/src/OnBloc/OBlElement.class.st
@@ -57,9 +57,3 @@ OBlElement >> states [
 
 	^ nil
 ]
-
-{ #category : #accessing }
-OBlElement >> styles [
-
-	^ nil
-]


### PR DESCRIPTION
I don't know why OBlElement>>styles was returning nil but some of my elements couldn't be displayed making my spaces all black and bugged

Is there a reason this was returning nil ? 